### PR TITLE
Koiree Destroy Endpoint

### DIFF
--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -15,7 +15,7 @@ class Api::V1::PostersController < ApplicationController
       render json: { error: "Poster not found" }, status: :not_found
     end
   end
-
+  
   def create
     render json: Poster.create(poster_params)
   end
@@ -23,6 +23,28 @@ class Api::V1::PostersController < ApplicationController
   def update
     render json: Poster.update(params[:id], poster_params)
   end
+
+  # DELETE /api/v1/posters/:id
+  def destroy
+    # Directly check for the poster until the error manager is implemented
+    poster = Poster.find_by(id: params[:id])
+
+    if poster
+      poster.destroy
+      head :no_content
+    else
+      render json: { error: "Poster not found" }, status: :not_found
+    end
+  end
+  
+  # def destroy
+  #   # Koiree: Let Error Manager handle if the poster is not found
+  #   poster = Poster.find(params[:id])
+
+  #   # Koiree: Destroy the record and return 204 No Content
+  #   poster.destroy
+  #   head :no_content
+  # end
 
   private
   

--- a/app/controllers/api/v1/posters_controller.rb
+++ b/app/controllers/api/v1/posters_controller.rb
@@ -36,7 +36,8 @@ class Api::V1::PostersController < ApplicationController
       render json: { error: "Poster not found" }, status: :not_found
     end
   end
-  
+
+  # Koiree: Whenever the Error Manager is implemented 
   # def destroy
   #   # Koiree: Let Error Manager handle if the poster is not found
   #   poster = Poster.find(params[:id])

--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -5,7 +5,7 @@ class Poster < ApplicationRecord
   # Validations for the Poster model
 
   # Ensure that the 'name' attribute is present and not empty
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   # Ensure that the 'description' attribute is present and not empty
   validates :description, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,10 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   
+ # Posters API Endpoints
   get "/api/v1/posters", to: "api/v1/posters#index"
   get "/api/v1/posters/:id", to: "api/v1/posters#show"
   post "/api/v1/posters", to: "api/v1/posters#create"
   patch "/api/v1/posters/:id", to: "api/v1/posters#update"
+  delete "/api/v1/posters/:id", to: "api/v1/posters#destroy" # Delete a poster
 end


### PR DESCRIPTION
### What does this PR do?
- Implements the DELETE Poster endpoint.
- Adds tests for successful deletion, not found errors, and edge cases (SQL Injection).

### Why is this needed?
- To allow users to delete posters from the API database.

### How was it tested?
- Manually tested using Postman.
- All RSpec tests passing.

### Relevant Tests
- `DELETE /api/v1/posters/:id`
- Edge cases: invalid ID, SQL injection attempt.